### PR TITLE
treewide: ELF symbol features + various improvements

### DIFF
--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -12,7 +12,7 @@ index 6b65d7d..f64c3c5 100644
          "WindowSize": 1000
      }
 diff --git a/src/libdramsys/DRAMSys/simulation/DRAMSys.cpp b/src/libdramsys/DRAMSys/simulation/DRAMSys.cpp
-index 2dbaacd..4671dec 100644
+index 2dbaacd..3fa7ab5 100644
 --- a/src/libdramsys/DRAMSys/simulation/DRAMSys.cpp
 +++ b/src/libdramsys/DRAMSys/simulation/DRAMSys.cpp
 @@ -126,6 +126,40 @@ const Configuration& DRAMSys::getConfig() const
@@ -27,13 +27,13 @@ index 2dbaacd..4671dec 100644
 +    return ptr;
 +}
 +
-+void DRAMSys::perloadByte(uint64_t addr, unsigned char data)
++void DRAMSys::preloadByte(uint64_t addr, unsigned char data)
 +{
 +    if (config.storeMode == Configuration::StoreMode::Store )
 +    {
 +        // uint64_t phy_addr = addressDecoder->decodeAddress(addr);
 +        for (auto& dram : drams)
-+            dram->perloadByteInDram(addr,data);
++            dram->preloadByteInDram(addr,data);
 +    }else{
 +        SC_REPORT_FATAL(this->name(), "Storage not configured!");
 +    }
@@ -57,7 +57,7 @@ index 2dbaacd..4671dec 100644
  {
      if (config.powerAnalysis)
 diff --git a/src/libdramsys/DRAMSys/simulation/DRAMSys.h b/src/libdramsys/DRAMSys/simulation/DRAMSys.h
-index 3202b88..4c19e5f 100644
+index 3202b88..15c4a59 100644
 --- a/src/libdramsys/DRAMSys/simulation/DRAMSys.h
 +++ b/src/libdramsys/DRAMSys/simulation/DRAMSys.h
 @@ -71,6 +71,9 @@ public:
@@ -65,13 +65,13 @@ index 3202b88..4c19e5f 100644
      const Configuration& getConfig() const;
      const AddressDecoder& getAddressDecoder() const { return *addressDecoder; }
 +    unsigned char * getDramBasePointer();
-+    void perloadByte(uint64_t addr, unsigned char data);
++    void preloadByte(uint64_t addr, unsigned char data);
 +    unsigned char checkByte(uint64_t addr);
  
      /**
       * Returns true if all memory controllers are in idle state.
 diff --git a/src/libdramsys/DRAMSys/simulation/dram/Dram.cpp b/src/libdramsys/DRAMSys/simulation/dram/Dram.cpp
-index a2c21dc..e537d38 100644
+index a2c21dc..55769ed 100644
 --- a/src/libdramsys/DRAMSys/simulation/dram/Dram.cpp
 +++ b/src/libdramsys/DRAMSys/simulation/dram/Dram.cpp
 @@ -111,6 +111,24 @@ Dram::~Dram()
@@ -83,7 +83,7 @@ index a2c21dc..e537d38 100644
 +    return memory;
 +}
 +
-+void Dram::perloadByteInDram(uint64_t addr, unsigned char data)
++void Dram::preloadByteInDram(uint64_t addr, unsigned char data)
 +{
 +    unsigned char *phyAddr = memory + addr;
 +    *phyAddr = data;
@@ -100,7 +100,7 @@ index a2c21dc..e537d38 100644
  {
  #ifdef DRAMPOWER
 diff --git a/src/libdramsys/DRAMSys/simulation/dram/Dram.h b/src/libdramsys/DRAMSys/simulation/dram/Dram.h
-index d800406..2ee2bce 100644
+index d800406..716432f 100644
 --- a/src/libdramsys/DRAMSys/simulation/dram/Dram.h
 +++ b/src/libdramsys/DRAMSys/simulation/dram/Dram.h
 @@ -88,6 +88,9 @@ public:
@@ -108,7 +108,7 @@ index d800406..2ee2bce 100644
      tlm_utils::simple_target_socket<Dram> tSocket;
  
 +    unsigned char * getDramBasePointer();
-+    void perloadByteInDram(uint64_t addr, unsigned char data);
++    void preloadByteInDram(uint64_t addr, unsigned char data);
 +    unsigned char checkByte(uint64_t addr);
      virtual void reportPower();
  
@@ -229,10 +229,10 @@ index 35f2ddf..3cff9dd 100644
  #include <DRAMSys/simulation/DRAMSysRecordable.h>
 diff --git a/src/simulator/simulator/dramsys_conv.h b/src/simulator/simulator/dramsys_conv.h
 new file mode 100644
-index 0000000..d9787f5
+index 0000000..a9ab650
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_conv.h
-@@ -0,0 +1,363 @@
+@@ -0,0 +1,359 @@
 +#pragma once
 +
 +#include "simulator/MemoryManager.h"
@@ -592,16 +592,12 @@ index 0000000..d9787f5
 +    }
 +
 +};
-+
-+
-+
-+
 diff --git a/src/simulator/simulator/dramsys_lib.cpp b/src/simulator/simulator/dramsys_lib.cpp
 new file mode 100644
-index 0000000..fb90e9a
+index 0000000..61fdda8
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_lib.cpp
-@@ -0,0 +1,253 @@
+@@ -0,0 +1,252 @@
 +#include "Simulator.h"
 +
 +#include <DRAMSys/config/DRAMSysConfiguration.h>
@@ -777,7 +773,7 @@ index 0000000..fb90e9a
 +}
 +
 +
-+extern "C" void cloes_dram(int dram_id) {
++extern "C" void close_dram(int dram_id) {
 +    if(dram_id == 0) sc_stop();
 +    delete list_of_conv[dram_id];
 +    delete list_of_DRAMsys[dram_id];
@@ -786,7 +782,7 @@ index 0000000..fb90e9a
 +
 +extern "C" void dram_preload_byte(int dram_id, uint64_t dram_addr_ofst, int byte_int) {
 +    // std::cout << "Load byte " << byte_int << ", in addr "<<dram_addr_ofst <<", DRAM id " << dram_id << std::endl;
-+    list_of_DRAMsys[dram_id]->perloadByte(dram_addr_ofst,byte_int);
++    list_of_DRAMsys[dram_id]->preloadByte(dram_addr_ofst,byte_int);
 +}
 +
 +extern "C" int dram_check_byte(int dram_id, uint64_t dram_addr_ofst) {
@@ -841,7 +837,7 @@ index 0000000..fb90e9a
 +        std::stringstream ss;
 +        ss << std::hex << read_byte;
 +        ss >> data;
-+        list_of_DRAMsys[dram_id]->perloadByte(addr,data);
++        list_of_DRAMsys[dram_id]->preloadByte(addr,data);
 +        addr++;
 +    }
 +    MemFile.close();
@@ -854,10 +850,9 @@ index 0000000..fb90e9a
 +    list_of_conv[dram_id]->registerCBRespMeth(resp_meth);
 +    list_of_conv[dram_id]->registerCBUpdateReqMeth(req_meth);
 +}
-+
 diff --git a/src/simulator/simulator/elfloader.cpp b/src/simulator/simulator/elfloader.cpp
 new file mode 100644
-index 0000000..57d7b6d
+index 0000000..9e095a1
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.cpp
 @@ -0,0 +1,106 @@
@@ -967,10 +962,9 @@ index 0000000..57d7b6d
 +
 +  munmap(buf, size);
 +}
-\ No newline at end of file
 diff --git a/src/simulator/simulator/elfloader.h b/src/simulator/simulator/elfloader.h
 new file mode 100644
-index 0000000..52c37b0
+index 0000000..1901b09
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.h
 @@ -0,0 +1,200 @@
@@ -1174,4 +1168,3 @@ index 0000000..52c37b0
 +void elfloader_read_elf(const char* filename, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer);
 +
 +#endif
-\ No newline at end of file

--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -594,10 +594,10 @@ index 0000000..a9ab650
 +};
 diff --git a/src/simulator/simulator/dramsys_lib.cpp b/src/simulator/simulator/dramsys_lib.cpp
 new file mode 100644
-index 0000000..61fdda8
+index 0000000..b173386
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_lib.cpp
-@@ -0,0 +1,252 @@
+@@ -0,0 +1,259 @@
 +#include "Simulator.h"
 +
 +#include <DRAMSys/config/DRAMSysConfiguration.h>
@@ -608,12 +608,13 @@ index 0000000..61fdda8
 +
 +std::vector<uint64_t>                               list_of_DRAMburst;
 +std::vector<uint64_t>                               list_of_DRAMsize;
++std::vector<uint64_t>                               list_of_DRAMbase;
 +std::vector<DRAMSys::DRAMSys *>                     list_of_DRAMsys;
 +std::vector<dramsys_conv *>                         list_of_conv;
 +std::vector<uint8_t *>                              list_of_wbuffer;
 +std::vector<uint8_t *>                              list_of_wstrobe;
 +
-+extern "C" int add_dram(char * resources_path, char * simulationJson_path){
++extern "C" int add_dram(char * resources_path, char * simulationJson_path, uint64_t dram_base) {
 +
 +    static int id = 0;
 +
@@ -670,6 +671,7 @@ index 0000000..61fdda8
 +    list_of_DRAMsys.push_back(dramSys);
 +    list_of_conv.push_back(conv);
 +    list_of_DRAMsize.push_back(dramChannelSize);
++    list_of_DRAMbase.push_back(dram_base);
 +    list_of_DRAMburst.push_back(dramMaxBurstByte);
 +
 +    uint8_t* wbuffer_ptr = new uint8_t [2048];
@@ -790,16 +792,21 @@ index 0000000..61fdda8
 +    return list_of_DRAMsys[dram_id]->checkByte(dram_addr_ofst);
 +}
 +
-+extern "C" void dram_load_elf(int dram_id, uint64_t dram_base_addr, char * elf_path) {
++extern "C" void dram_load_elf(char * elf_path) {
 +    std::string app_binary;
 +    app_binary = elf_path;
 +    std::ifstream f(app_binary.c_str());
++    std::vector<unsigned char *> list_of_DRAMbuf_ptr;
++    for (int i = 0; i < list_of_DRAMsys.size(); i++)
++    {
++        list_of_DRAMbuf_ptr.push_back(list_of_DRAMsys[i]->getDramBasePointer());
++    }
 +    if (f.good())
 +    {
-+        elfloader_read_elf(app_binary.c_str(), list_of_DRAMsize[dram_id], dram_base_addr, list_of_DRAMsys[dram_id]->getDramBasePointer());
-+        std::cout << "Load elf file [" << app_binary << "] in DRAM id " << dram_id << std::endl;
++        elfloader_read_elf(app_binary.c_str(), list_of_DRAMsize, list_of_DRAMbase, list_of_DRAMbuf_ptr);
++        std::cout << "[DRAMSys] Load elf file [" << app_binary << "] in DRAM " << std::endl;
 +    } else {
-+        std::cout << "Can not Load elf file [" << app_binary << "] in DRAM id " << dram_id << " : File not found"<< std::endl;
++        std::cout << "[DRAMSys] Can not Load elf file [" << app_binary << "] in DRAM : File not found"<< std::endl;
 +    }
 +
 +}
@@ -852,10 +859,10 @@ index 0000000..61fdda8
 +}
 diff --git a/src/simulator/simulator/elfloader.cpp b/src/simulator/simulator/elfloader.cpp
 new file mode 100644
-index 0000000..2cc3154
+index 0000000..cf2f511
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.cpp
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,137 @@
 +#include "elfloader.h"
 +
 +#define SHT_PROGBITS 0x1
@@ -868,11 +875,23 @@ index 0000000..2cc3154
 +reg_t entry;
 +int section_index = 0;
 +
-+void write (uint64_t address, uint64_t len, uint8_t* buf, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer) {
-+    std::cout << "[DRAMSys] elfloader section addr: 0x" << std::hex << address << " len: 0x" << len <<std::endl;
-+    for (int i = 0; i < len; i++) {
-+        assert( address - dest_base_addr + i < dest_size);
-+        dest_buffer[address - dest_base_addr + i] = buf[i];
++void write(uint64_t address,
++           uint64_t len,
++           uint8_t* buf,
++           std::vector<uint64_t>& dest_size,
++           std::vector<uint64_t>& dest_base,
++           std::vector<unsigned char*>& dest_buffer)
++{
++    for (int i = 0; i < dest_size.size(); i++)
++    {
++        if (address >= dest_base[i] && address < dest_base[i] + dest_size[i]) {
++            for (int j = 0; j < len; j++) {
++                assert( address - dest_base[i] + j < dest_size[i]);
++                dest_buffer[i][address - dest_base[i] + j] = buf[j];
++            }
++            std::cout << "[DRAMSys] elfloader section addr: 0x" << std::hex << address << " len: 0x" << len << " to channel " << i << std::endl;
++            return;
++        }
 +    }
 +}
 +
@@ -897,7 +916,10 @@ index 0000000..2cc3154
 +    return symbols[sym];
 +}
 +
-+void elfloader_read_elf(const char* filename, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer) {
++void elfloader_read_elf(const char* filename,
++                        std::vector<uint64_t>& dest_size,
++                        std::vector<uint64_t>& dest_base,
++                        std::vector<unsigned char *>& dest_buffer) {
 +  int fd = open(filename, O_RDONLY);
 +  struct stat s;
 +  assert(fd != -1);
@@ -929,10 +951,10 @@ index 0000000..2cc3154
 +      if(bswap(ph[i].p_type) == PT_LOAD && bswap(ph[i].p_memsz)) {	\
 +        if (bswap(ph[i].p_filesz)) {					\
 +          assert(size >= bswap(ph[i].p_offset) + bswap(ph[i].p_filesz)); \
-+          write(bswap(ph[i].p_paddr), bswap(ph[i].p_filesz), (uint8_t*)buf + bswap(ph[i].p_offset), dest_size, dest_base_addr, dest_buffer); \
++          write(bswap(ph[i].p_paddr), bswap(ph[i].p_filesz), (uint8_t*)buf + bswap(ph[i].p_offset), dest_size, dest_base, dest_buffer); \
 +        } \
 +        zeros.resize(bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz)); \
-+        write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz), bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz), &zeros[0], dest_size, dest_base_addr, dest_buffer); \
++        write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz), bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz), &zeros[0], dest_size, dest_base, dest_buffer); \
 +      } \
 +    } \
 +    shdr_t* sh = (shdr_t*)(buf + bswap(eh->e_shoff)); \
@@ -980,10 +1002,10 @@ index 0000000..2cc3154
 +}
 diff --git a/src/simulator/simulator/elfloader.h b/src/simulator/simulator/elfloader.h
 new file mode 100644
-index 0000000..5e3f573
+index 0000000..50eb7e8
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.h
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,225 @@
 +#ifndef _ELFLOADER_H
 +#define _ELFLOADER_H
 +
@@ -1203,6 +1225,9 @@ index 0000000..5e3f573
 +uint64_t elf_get_symbol_addr(const char* sym);
 +char elfloader_get_section (long long* address, long long* len);
 +char elfloader_read_section (long long address, unsigned char * buf);
-+void elfloader_read_elf(const char* filename, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer);
++void elfloader_read_elf(const char* filename,
++                        std::vector<uint64_t>& dest_size,
++                        std::vector<uint64_t>& dest_base,
++                        std::vector<unsigned char*>& dest_buffer);
 +
 +#endif

--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -594,10 +594,10 @@ index 0000000..a9ab650
 +};
 diff --git a/src/simulator/simulator/dramsys_lib.cpp b/src/simulator/simulator/dramsys_lib.cpp
 new file mode 100644
-index 0000000..b173386
+index 0000000..17940ba
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_lib.cpp
-@@ -0,0 +1,259 @@
+@@ -0,0 +1,294 @@
 +#include "Simulator.h"
 +
 +#include <DRAMSys/config/DRAMSysConfiguration.h>
@@ -783,13 +783,49 @@ index 0000000..b173386
 +
 +
 +extern "C" void dram_preload_byte(int dram_id, uint64_t dram_addr_ofst, int byte_int) {
-+    // std::cout << "Load byte " << byte_int << ", in addr "<<dram_addr_ofst <<", DRAM id " << dram_id << std::endl;
 +    list_of_DRAMsys[dram_id]->preloadByte(dram_addr_ofst,byte_int);
 +}
 +
 +extern "C" int dram_check_byte(int dram_id, uint64_t dram_addr_ofst) {
-+    // std::cout << "Load byte " << byte_int << ", in addr "<<dram_addr_ofst <<", DRAM id " << dram_id << std::endl;
 +    return list_of_DRAMsys[dram_id]->checkByte(dram_addr_ofst);
++}
++
++int get_dram_id(uint64_t addr) {
++    int dram_id = -1;
++    for (int i = 0; i < list_of_DRAMsys.size(); i++) {
++        if (addr >= list_of_DRAMbase[i] && addr < list_of_DRAMbase[i] + list_of_DRAMsize[i]) {
++            dram_id = i;
++            break;
++        }
++    }
++    if (dram_id == -1) {
++        std::cout << "[DRAMSYS] Address " << addr << " is out of range of all DRAMs" << std::endl;
++    }
++    return dram_id;
++}
++
++extern "C" int dram_check_elf_symbol(const char* sym) {
++    // Get the address of the symbol in the ELF file
++    uint64_t symbol_ptr = elf_get_symbol_addr(sym);
++    // Get the DRAM id of the symbol
++    int dram_id = get_dram_id(symbol_ptr);
++    // Get the value of the symbol in the DRAM
++    int value = 0;
++    for (int i = 0; i < 4; i++) {
++        value |= list_of_DRAMsys[dram_id]->checkByte(symbol_ptr + i - list_of_DRAMbase[dram_id]) << (i*8);
++    }
++    return value;
++}
++
++extern "C" void dram_write_elf_symbol(const char* sym, int value) {
++    // Get the address of the symbol in the ELF file
++    uint64_t symbol_ptr = elf_get_symbol_addr(sym);
++    // Get the DRAM id of the symbol
++    int dram_id = get_dram_id(symbol_ptr);
++    // Write the value of the symbol in the DRAM
++    for (int i = 0; i < 4; i++) {
++        list_of_DRAMsys[dram_id]->preloadByte(symbol_ptr + i - list_of_DRAMbase[dram_id], (value >> (i*8)) & 0xFF);
++    }
 +}
 +
 +extern "C" void dram_load_elf(char * elf_path) {
@@ -808,7 +844,6 @@ index 0000000..b173386
 +    } else {
 +        std::cout << "[DRAMSys] Can not Load elf file [" << app_binary << "] in DRAM : File not found"<< std::endl;
 +    }
-+
 +}
 +
 +extern "C" void dram_load_memfile(int dram_id, uint64_t addr_ofst, char * mem_path){

--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -852,10 +852,10 @@ index 0000000..61fdda8
 +}
 diff --git a/src/simulator/simulator/elfloader.cpp b/src/simulator/simulator/elfloader.cpp
 new file mode 100644
-index 0000000..9e095a1
+index 0000000..2cc3154
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.cpp
-@@ -0,0 +1,106 @@
+@@ -0,0 +1,122 @@
 +#include "elfloader.h"
 +
 +#define SHT_PROGBITS 0x1
@@ -869,11 +869,10 @@ index 0000000..9e095a1
 +int section_index = 0;
 +
 +void write (uint64_t address, uint64_t len, uint8_t* buf, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer) {
-+    std::cout << "elfloader section addr: 0x" << std::hex << address << " len: 0x" << len <<std::endl;
++    std::cout << "[DRAMSys] elfloader section addr: 0x" << std::hex << address << " len: 0x" << len <<std::endl;
 +    for (int i = 0; i < len; i++) {
 +        assert( address - dest_base_addr + i < dest_size);
 +        dest_buffer[address - dest_base_addr + i] = buf[i];
-+        // std::cout << "offset 0x" << address - dest_base_addr + i << "= 0x" << std::hex <<(unsigned int)buf[i] <<std::endl;
 +    }
 +}
 +
@@ -890,84 +889,101 @@ index 0000000..9e095a1
 +    } else return 0;
 +}
 +
++// Get the address of a symbol defined in the elf file
++uint64_t elf_get_symbol_addr(const char* sym) {
++    if (symbols.count(sym) == 0) {
++      std::cout << "[DRAMSys] Symbol " << sym << " not found" << std::endl;
++    }
++    return symbols[sym];
++}
 +
 +void elfloader_read_elf(const char* filename, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer) {
-+    int fd = open(filename, O_RDONLY);
-+    struct stat s;
-+    assert(fd != -1);
-+    if (fstat(fd, &s) < 0)
++  int fd = open(filename, O_RDONLY);
++  struct stat s;
++  assert(fd != -1);
++  if (fstat(fd, &s) < 0)
 +    abort();
-+    size_t size = s.st_size;
++  size_t size = s.st_size;
 +
-+    char* buf = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
-+    assert(buf != MAP_FAILED);
-+    close(fd);
++  char* buf = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
++  assert(buf != MAP_FAILED);
++  close(fd);
 +
-+    assert(size >= sizeof(Elf64_Ehdr));
-+    const Elf64_Ehdr* eh64 = (const Elf64_Ehdr*)buf;
-+    assert(IS_ELF32(*eh64) || IS_ELF64(*eh64));
++  assert(size >= sizeof(Elf64_Ehdr));
++  const Elf64_Ehdr* eh64 = (const Elf64_Ehdr*)buf;
++  assert(IS_ELF32(*eh64) || IS_ELF64(*eh64));
++  assert(IS_ELFLE(*eh64) || IS_ELFBE(*eh64));
++  assert(IS_ELF_EXEC(*eh64));
++  assert(IS_ELF_RISCV(*eh64) || IS_ELF_EM_NONE(*eh64));
++  assert(IS_ELF_VCURRENT(*eh64));
 +
++  std::vector<uint8_t> zeros;
++  // std::map<std::string, uint64_t> symbols;
 +
-+
-+    std::vector<uint8_t> zeros;
-+    std::map<std::string, uint64_t> symbols;
-+
-+    #define LOAD_ELF(ehdr_t, phdr_t, shdr_t, sym_t) do { \
++  #define LOAD_ELF(ehdr_t, phdr_t, shdr_t, sym_t, bswap) do { \
 +    ehdr_t* eh = (ehdr_t*)buf; \
-+    phdr_t* ph = (phdr_t*)(buf + eh->e_phoff); \
-+    entry = eh->e_entry; \
-+    assert(size >= eh->e_phoff + eh->e_phnum*sizeof(*ph)); \
-+    for (unsigned i = 0; i < eh->e_phnum; i++) { \
-+      if(ph[i].p_type == PT_LOAD && ph[i].p_memsz) { \
-+        if (ph[i].p_filesz) { \
-+          assert(size >= ph[i].p_offset + ph[i].p_filesz); \
-+          sections.push_back(std::make_pair(ph[i].p_paddr, ph[i].p_memsz)); \
-+          write(ph[i].p_paddr, ph[i].p_filesz, (uint8_t*)buf + ph[i].p_offset, dest_size, dest_base_addr, dest_buffer); \
++    phdr_t* ph = (phdr_t*)(buf + bswap(eh->e_phoff)); \
++    entry = bswap(eh->e_entry); \
++    assert(size >= bswap(eh->e_phoff) + bswap(eh->e_phnum)*sizeof(*ph)); \
++    for (unsigned i = 0; i < bswap(eh->e_phnum); i++) {			\
++      if(bswap(ph[i].p_type) == PT_LOAD && bswap(ph[i].p_memsz)) {	\
++        if (bswap(ph[i].p_filesz)) {					\
++          assert(size >= bswap(ph[i].p_offset) + bswap(ph[i].p_filesz)); \
++          write(bswap(ph[i].p_paddr), bswap(ph[i].p_filesz), (uint8_t*)buf + bswap(ph[i].p_offset), dest_size, dest_base_addr, dest_buffer); \
 +        } \
-+        zeros.resize(ph[i].p_memsz - ph[i].p_filesz); \
++        zeros.resize(bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz)); \
++        write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz), bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz), &zeros[0], dest_size, dest_base_addr, dest_buffer); \
 +      } \
 +    } \
-+    shdr_t* sh = (shdr_t*)(buf + eh->e_shoff); \
-+    assert(size >= eh->e_shoff + eh->e_shnum*sizeof(*sh)); \
-+    assert(eh->e_shstrndx < eh->e_shnum); \
-+    assert(size >= sh[eh->e_shstrndx].sh_offset + sh[eh->e_shstrndx].sh_size); \
-+    char *shstrtab = buf + sh[eh->e_shstrndx].sh_offset; \
++    shdr_t* sh = (shdr_t*)(buf + bswap(eh->e_shoff)); \
++    assert(size >= bswap(eh->e_shoff) + bswap(eh->e_shnum)*sizeof(*sh)); \
++    assert(bswap(eh->e_shstrndx) < bswap(eh->e_shnum)); \
++    assert(size >= bswap(sh[bswap(eh->e_shstrndx)].sh_offset) + bswap(sh[bswap(eh->e_shstrndx)].sh_size)); \
++    char *shstrtab = buf + bswap(sh[bswap(eh->e_shstrndx)].sh_offset);	\
 +    unsigned strtabidx = 0, symtabidx = 0; \
-+    for (unsigned i = 0; i < eh->e_shnum; i++) { \
-+      unsigned max_len = sh[eh->e_shstrndx].sh_size - sh[i].sh_name; \
-+      if ((sh[i].sh_type & SHT_GROUP) && strcmp(shstrtab + sh[i].sh_name, ".strtab") != 0 && strcmp(shstrtab + sh[i].sh_name, ".shstrtab") != 0) \
-+      assert(strnlen(shstrtab + sh[i].sh_name, max_len) < max_len); \
-+      if (sh[i].sh_type & SHT_PROGBITS) continue; \
-+      if (strcmp(shstrtab + sh[i].sh_name, ".strtab") == 0) \
++    for (unsigned i = 0; i < bswap(eh->e_shnum); i++) {		     \
++      unsigned max_len = bswap(sh[bswap(eh->e_shstrndx)].sh_size) - bswap(sh[i].sh_name); \
++      assert(bswap(sh[i].sh_name) < bswap(sh[bswap(eh->e_shstrndx)].sh_size));	\
++      assert(strnlen(shstrtab + bswap(sh[i].sh_name), max_len) < max_len); \
++      if (bswap(sh[i].sh_type) & SHT_NOBITS) continue; \
++      assert(size >= bswap(sh[i].sh_offset) + bswap(sh[i].sh_size)); \
++      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".strtab") == 0) \
 +        strtabidx = i; \
-+      if (strcmp(shstrtab + sh[i].sh_name, ".symtab") == 0) \
++      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".symtab") == 0) \
 +        symtabidx = i; \
 +    } \
 +    if (strtabidx && symtabidx) { \
-+      char* strtab = buf + sh[strtabidx].sh_offset; \
-+      sym_t* sym = (sym_t*)(buf + sh[symtabidx].sh_offset); \
-+      for (unsigned i = 0; i < sh[symtabidx].sh_size/sizeof(sym_t); i++) { \
-+        unsigned max_len = sh[strtabidx].sh_size - sym[i].st_name; \
-+        assert(sym[i].st_name < sh[strtabidx].  sh_size); \
-+        assert(strnlen(strtab + sym[i].st_name, max_len) < max_len); \
-+        symbols[strtab + sym[i].st_name] = sym[i].st_value; \
++      char* strtab = buf + bswap(sh[strtabidx].sh_offset); \
++      sym_t* sym = (sym_t*)(buf + bswap(sh[symtabidx].sh_offset)); \
++      for (unsigned i = 0; i < bswap(sh[symtabidx].sh_size)/sizeof(sym_t); i++) { \
++        unsigned max_len = bswap(sh[strtabidx].sh_size) - bswap(sym[i].st_name); \
++        assert(bswap(sym[i].st_name) < bswap(sh[strtabidx].sh_size));	\
++        assert(strnlen(strtab + bswap(sym[i].st_name), max_len) < max_len); \
++        symbols[strtab + bswap(sym[i].st_name)] = bswap(sym[i].st_value); \
 +      } \
 +    } \
-+    } while(0)
++  } while(0)
 +
-+  if (IS_ELF32(*eh64))
-+    LOAD_ELF(Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Sym);
-+  else
-+    LOAD_ELF(Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Sym);
++  if (IS_ELFLE(*eh64)) {
++    if (IS_ELF32(*eh64))
++      LOAD_ELF(Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Sym, from_le);
++    else
++      LOAD_ELF(Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Sym, from_le);
++  } else {
++    if (IS_ELF32(*eh64))
++      LOAD_ELF(Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Sym, from_be);
++    else
++      LOAD_ELF(Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Sym, from_be);
++  }
 +
 +  munmap(buf, size);
 +}
 diff --git a/src/simulator/simulator/elfloader.h b/src/simulator/simulator/elfloader.h
 new file mode 100644
-index 0000000..1901b09
+index 0000000..5e3f573
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.h
-@@ -0,0 +1,200 @@
+@@ -0,0 +1,222 @@
 +#ifndef _ELFLOADER_H
 +#define _ELFLOADER_H
 +
@@ -1003,6 +1019,27 @@ index 0000000..1901b09
 +#define IS_ELF_RISCV(hdr) (IS_ELF(hdr) && (hdr).e_machine == EM_RISCV)
 +#define IS_ELF_EM_NONE(hdr) (IS_ELF(hdr) && (hdr).e_machine == EM_NONE)
 +#define IS_ELF_VCURRENT(hdr) (IS_ELF(hdr) && (hdr).e_version == EV_CURRENT)
++
++static inline uint8_t swap(uint8_t n) { return n; }
++static inline uint16_t swap(uint16_t n) { return (n >> 8) | (n << 8); }
++static inline uint32_t swap(uint32_t n) { return (swap(uint16_t(n)) << 16) | swap(uint16_t(n >> 16)); }
++static inline uint64_t swap(uint64_t n) { return (uint64_t(swap(uint32_t(n))) << 32) | swap(uint32_t(n >> 32)); }
++static inline int8_t swap(int8_t n) { return n; }
++static inline int16_t swap(int16_t n) { return int16_t(swap(uint16_t(n))); }
++static inline int32_t swap(int32_t n) { return int32_t(swap(uint32_t(n))); }
++static inline int64_t swap(int64_t n) { return int64_t(swap(uint64_t(n))); }
++
++#ifdef WORDS_BIGENDIAN
++template<typename T> static inline T from_be(T n) { return n; }
++template<typename T> static inline T to_be(T n) { return n; }
++template<typename T> static inline T from_le(T n) { return swap(n); }
++template<typename T> static inline T to_le(T n) { return swap(n); }
++#else
++template<typename T> static inline T from_le(T n) { return n; }
++template<typename T> static inline T to_le(T n) { return n; }
++template<typename T> static inline T from_be(T n) { return swap(n); }
++template<typename T> static inline T to_be(T n) { return swap(n); }
++#endif
 +
 +#define PT_LOAD 1
 +
@@ -1163,6 +1200,7 @@ index 0000000..1901b09
 +  chunked_memif_t* cmemif;
 +};
 +
++uint64_t elf_get_symbol_addr(const char* sym);
 +char elfloader_get_section (long long* address, long long* len);
 +char elfloader_read_section (long long address, unsigned char * buf);
 +void elfloader_read_elf(const char* filename, long long dest_size, long long dest_base_addr, unsigned char * dest_buffer);

--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -594,7 +594,7 @@ index 0000000..a9ab650
 +};
 diff --git a/src/simulator/simulator/dramsys_lib.cpp b/src/simulator/simulator/dramsys_lib.cpp
 new file mode 100644
-index 0000000..17940ba
+index 0000000..e23fca7
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_lib.cpp
 @@ -0,0 +1,294 @@
@@ -681,7 +681,7 @@ index 0000000..17940ba
 +    list_of_wstrobe.push_back(wstrobe_ptr);
 +
 +
-+    std::cout << "the instantiated DRAM id is: " << id << std::endl;
++    std::cout << "[DRAMSys] DRAM " << id << " is added with base address 0x" << std::hex << dram_base << std::endl;
 +
 +    int res = id;
 +    id += 1;
@@ -840,9 +840,9 @@ index 0000000..17940ba
 +    if (f.good())
 +    {
 +        elfloader_read_elf(app_binary.c_str(), list_of_DRAMsize, list_of_DRAMbase, list_of_DRAMbuf_ptr);
-+        std::cout << "[DRAMSys] Load elf file [" << app_binary << "] in DRAM " << std::endl;
++        std::cout << "[DRAMSys] Load elf file" << app_binary << " to DRAM " << std::endl;
 +    } else {
-+        std::cout << "[DRAMSys] Can not Load elf file [" << app_binary << "] in DRAM : File not found"<< std::endl;
++        std::cout << "[DRAMSys] Can not Load elf file" << app_binary << " : File not found"<< std::endl;
 +    }
 +}
 +
@@ -851,12 +851,12 @@ index 0000000..17940ba
 +    //Memory pre-loading
 +    std::string read_byte;
 +    uint64_t addr = addr_ofst;
-+    std::cout << "Load mem file [" << mem_path << "] in DRAM id " << dram_id << " from addr " << addr_ofst << std::endl;
++    std::cout << "[DRAMSys] Load mem file [" << mem_path << "] in DRAM id " << dram_id << " from addr " << addr_ofst << std::endl;
 +    std::ifstream MemFile(mem_path);
 +    //sanity check
 +    if (!MemFile.good())
 +    {
-+        std::cout << "Can not Load Mem file [" << mem_path << "] in DRAM id " << dram_id << " : File not found"<< std::endl;
++        std::cout << "[DRAMSys] Can not Load Mem file [" << mem_path << "] in DRAM id " << dram_id << " : File not found"<< std::endl;
 +        return;
 +    }
 +
@@ -894,7 +894,7 @@ index 0000000..17940ba
 +}
 diff --git a/src/simulator/simulator/elfloader.cpp b/src/simulator/simulator/elfloader.cpp
 new file mode 100644
-index 0000000..cf2f511
+index 0000000..e95266c
 --- /dev/null
 +++ b/src/simulator/simulator/elfloader.cpp
 @@ -0,0 +1,137 @@
@@ -924,7 +924,7 @@ index 0000000..cf2f511
 +                assert( address - dest_base[i] + j < dest_size[i]);
 +                dest_buffer[i][address - dest_base[i] + j] = buf[j];
 +            }
-+            std::cout << "[DRAMSys] elfloader section addr: 0x" << std::hex << address << " len: 0x" << len << " to channel " << i << std::endl;
++            std::cout << "[DRAMSys] elfloader section addr: 0x" << std::hex << address << " len: 0x" << len << " to DRAM " << i << std::endl;
 +            return;
 +        }
 +    }

--- a/src/dram_sim_engine.sv
+++ b/src/dram_sim_engine.sv
@@ -1,4 +1,4 @@
-// Copyright 2023 ETH Zurich and 
+// Copyright 2023 ETH Zurich and
 // University of Bologna
 
 // Solderpad Hardware License
@@ -9,21 +9,21 @@
 // Author: Chi Zhang <chizhang@iis.ee.ethz.ch>, ETH Zurich
 // Date: 07.June.2023
 
-// clock engine for dram simulation
 
 import "DPI-C" function void run_ns(input int ns);
 
+// clock engine for dram simulation
 module dram_sim_engine #(
-	parameter int unsigned ClkPeriodNs    = 10
-	)(
-	input  logic                 clk_i,      // Clock
-	input  logic                 rst_ni     // Asynchronous reset active low
+	parameter time ClkPeriod	= 1ns
+) (
+	input logic clk_i,	// Clock
+	input logic rst_ni	// Asynchronous reset active low
 );
 
 	always_ff @(posedge clk_i or negedge rst_ni) begin : proc_dram_engine
 		if(rst_ni) begin
 			// run DRAMsys every clk
-			run_ns(ClkPeriodNs);
+			run_ns(int'(ClkPeriod / 1ns));
 		end
 	end
 

--- a/src/sim_dram.sv
+++ b/src/sim_dram.sv
@@ -23,7 +23,7 @@ import "DPI-C" function void dram_get_read_rsp(input int dram_id, input longint 
 import "DPI-C" function int dram_get_read_rsp_byte(input int dram_id);
 import "DPI-C" function void dram_preload_byte(input int dram_id, input longint dram_addr_ofst, input int byte_int);
 import "DPI-C" function int dram_check_byte(input int dram_id, input longint dram_addr_ofst);
-import "DPI-C" function void dram_load_elf(input int dram_id, input longint dram_base_addr, input string app_path);
+import "DPI-C" function void dram_load_elf(input string app_path);
 import "DPI-C" function void dram_load_memfile(input int dram_id, input longint addr_ofst, input string mem_path);
 import "DPI-C" function void close_dram(input int dram_id);
 
@@ -105,7 +105,7 @@ initial begin
         $warning("No app found to preload in DRAM !!");
     end else begin
         $display("loading app: %s\n",app_path);
-        dram_load_elf(dram_id, BASE, app_path);
+        dram_load_elf(app_path);
     end
 
     void'($value$plusargs("MEM=%s", mem_path));
@@ -130,8 +130,8 @@ task check_a_byte_in_dram(input longint dram_addr_ofst, output logic[7:0] data_b
 endtask
 
 //interface to manualy modify DRAM
-task preload_elf_binary(input longint dram_addr_ofst, input string elf_binary );
-    dram_load_elf(dram_id, dram_addr_ofst, elf_binary);
+task preload_elf_binary(input string elf_binary );
+    dram_load_elf(elf_binary);
 endtask
 
 always_ff @(negedge clk_i or posedge clk_i or negedge rst_ni) begin : proc_dram

--- a/src/sim_dram.sv
+++ b/src/sim_dram.sv
@@ -10,8 +10,7 @@
 // Date: 07.June.2023
 
 // dram model using dramsys library
-
-import "DPI-C" function int add_dram(input string resources_path, input string simulationJson_path);
+import "DPI-C" function int add_dram(input string resources_path, input string simulationJson_path, input longint dram_base_addr);
 import "DPI-C" function int dram_get_inflight_read(input int dram_id);
 import "DPI-C" function int dram_can_accept_req(input int dram_id);
 import "DPI-C" function int dram_has_write_rsp(input int dram_id);
@@ -100,7 +99,7 @@ initial begin
     if (resources_path.len() == 0 || simulationJson_path.len() == 0) begin
         $fatal(1,"no DRAMsys configuration found!");
     end
-    dram_id = add_dram(resources_path, simulationJson_path);
+    dram_id = add_dram(resources_path, simulationJson_path, BASE);
     void'($value$plusargs("ONE_DRAM_PRELOAD=%s", app_path));
     if (app_path.len() == 0) begin
         $warning("No app found to preload in DRAM !!");
@@ -118,7 +117,7 @@ initial begin
     end
 end
 
-//interface to manuly modify DRAM
+//interface to manualy modify DRAM
 task load_a_byte_to_dram(input longint dram_addr_ofst, input int data_byte );
     dram_preload_byte(dram_id, dram_addr_ofst, data_byte);
 endtask
@@ -130,7 +129,7 @@ task check_a_byte_in_dram(input longint dram_addr_ofst, output logic[7:0] data_b
     data_byte = byte_int;
 endtask
 
-//interface to manuly modify DRAM
+//interface to manualy modify DRAM
 task preload_elf_binary(input longint dram_addr_ofst, input string elf_binary );
     dram_load_elf(dram_id, dram_addr_ofst, elf_binary);
 endtask

--- a/src/sim_dram.sv
+++ b/src/sim_dram.sv
@@ -1,4 +1,4 @@
-// Copyright 2023 ETH Zurich and 
+// Copyright 2023 ETH Zurich and
 // University of Bologna
 
 // Solderpad Hardware License
@@ -26,7 +26,7 @@ import "DPI-C" function void dram_preload_byte(input int dram_id, input longint 
 import "DPI-C" function int dram_check_byte(input int dram_id, input longint dram_addr_ofst);
 import "DPI-C" function void dram_load_elf(input int dram_id, input longint dram_base_addr, input string app_path);
 import "DPI-C" function void dram_load_memfile(input int dram_id, input longint addr_ofst, input string mem_path);
-import "DPI-C" function void cloes_dram(input int dram_id);
+import "DPI-C" function void close_dram(input int dram_id);
 
 
 module sim_dram #(
@@ -43,7 +43,7 @@ module sim_dram #(
     input  logic                 clk_i,      // Clock
     input  logic                 rst_ni,     // Asynchronous reset active low
     // requests ports
-    input  logic                 req_valid_i,// request valid 
+    input  logic                 req_valid_i,// request valid
     output logic                 req_ready_o,// request ready
     input  logic                 we_i,       // write enable
     input  addr_t                addr_i,     // request address
@@ -94,7 +94,7 @@ initial begin
         simulationJson_path = {resources_path,"/",CustomerDRAM,".json"};
         $display("Use Customer DRAM configuration: %s\n",simulationJson_path);
     end
-    
+
     $display("resources_path= %s\n",resources_path);
     $display("simulationJson_path= %s\n",simulationJson_path);
     if (resources_path.len() == 0 || simulationJson_path.len() == 0) begin
@@ -184,7 +184,7 @@ always_ff @(negedge clk_i or posedge clk_i or negedge rst_ni) begin : proc_dram
 
     end else begin//negedge clk
 
-        //rsponse 
+        //response
         if (~rsp_valid_o) begin
             if (dram_has_read_rsp(dram_id)) begin
                 int get_byte_int;
@@ -207,7 +207,7 @@ always_ff @(negedge clk_i or posedge clk_i or negedge rst_ni) begin : proc_dram
                 b_valid_o <= 1;
             end
         end
-            
+
     end
 
 end
@@ -215,7 +215,7 @@ end
 
 
 final begin
-    cloes_dram(dram_id);
+    close_dram(dram_id);
 end
 
 endmodule : sim_dram

--- a/src/sim_dram.sv
+++ b/src/sim_dram.sv
@@ -101,18 +101,14 @@ initial begin
     end
     dram_id = add_dram(resources_path, simulationJson_path, BASE);
     void'($value$plusargs("ONE_DRAM_PRELOAD=%s", app_path));
-    if (app_path.len() == 0) begin
-        $warning("No app found to preload in DRAM !!");
-    end else begin
-        $display("loading app: %s\n",app_path);
+    if (app_path.len() != 0) begin
+        $display("[DRAMSys] Preloading elf: %s\n",app_path);
         dram_load_elf(app_path);
     end
 
     void'($value$plusargs("MEM=%s", mem_path));
-    if (mem_path.len() == 0) begin
-        $warning("No mem found to preload in DRAM !!");
-    end else begin
-        $display("loading mem: %s\n",mem_path);
+    if (mem_path.len() != 0) begin
+        $display("[DRAMSys] Preloading mem: %s\n",mem_path);
         dram_load_memfile(dram_id, 0, mem_path);
     end
 end

--- a/src/sim_dram.sv
+++ b/src/sim_dram.sv
@@ -90,25 +90,25 @@ initial begin
     endcase
 
     if (CustomerDRAM != "none") begin
-        simulationJson_path = {resources_path,"/",CustomerDRAM,".json"};
-        $display("Use Customer DRAM configuration: %s\n",simulationJson_path);
+        simulationJson_path = {resources_path, "/", CustomerDRAM, ".json"};
+        $display("[DRAMSys] Use Customer DRAM configuration: %s",simulationJson_path);
     end
 
-    $display("resources_path= %s\n",resources_path);
-    $display("simulationJson_path= %s\n",simulationJson_path);
+    $display("[DRAMSys] resources_path=%s", resources_path);
+    $display("[DRAMSys] simulationJson_path=%s", simulationJson_path);
     if (resources_path.len() == 0 || simulationJson_path.len() == 0) begin
-        $fatal(1,"no DRAMsys configuration found!");
+        $fatal(1,"[DRAMSys] no DRAMsys configuration found!");
     end
     dram_id = add_dram(resources_path, simulationJson_path, BASE);
     void'($value$plusargs("ONE_DRAM_PRELOAD=%s", app_path));
     if (app_path.len() != 0) begin
-        $display("[DRAMSys] Preloading elf: %s\n",app_path);
+        $display("[DRAMSys] Preloading elf: %s\n", app_path);
         dram_load_elf(app_path);
     end
 
     void'($value$plusargs("MEM=%s", mem_path));
     if (mem_path.len() != 0) begin
-        $display("[DRAMSys] Preloading mem: %s\n",mem_path);
+        $display("[DRAMSys] Preloading mem: %s\n", mem_path);
         dram_load_memfile(dram_id, 0, mem_path);
     end
 end


### PR DESCRIPTION
## Added

* Added `dram_check_elf_symbol`, `dram_write_elf_symbol` DPI-C function calls. They are used in Snitch simulations which is based on `fesvr` where the return code is written to a specific symbol placed in the ELF.
* ELF sections can be placed in multiple DRAM channels. DRAMSys automatically determines the channel based on the section start address (a section spanning over multiple channels is not supported, however). With an appropriate linker script, data can be placed in specific channels already in the binary.

## Changed
* The base address of each DRAM channel is now provided the first time when `add_dram` is called and then stored internally. This makes it possible to get rid of selecting a specific DRAM channel since the `dram_id` is calculated internally, based on the address.
* Changed the elfloader which now also populates the `symbols` table. This is required for checking symbols in the ELF
* Various typo fixes and slightly improved logging messages. They are now in general prefixed with `[DRAMSys]` to differentiate them better from other stdouts in a simulation.
* Clock period is passed as a parameter of type `time` instead of `int` to `dram_sim_engine`, which is more appropriate for testbenches.