### PR TITLE
sim_dram: Prettier waves + AXI compliant valid/ready 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+name: dramsys_lib
+
+on: [push, pull_request]
+
+jobs:
+  build-dramsys-lib:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Fetch and patch DRAMSys
+      run: |
+        cd dramsys_lib
+        git clone https://github.com/tukl-msd/DRAMSys.git
+        cd DRAMSys
+        git reset --hard 8e021ea
+        git apply ../dramsys_lib_patch
+    - name: Build DRAMSys
+      run: |
+        mkdir -p dramsys_lib/DRAMSys/build
+        cd dramsys_lib/DRAMSys/build
+        cmake -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC -D DRAMSYS_WITH_DRAMPOWER=ON ..
+        make -j

--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -229,7 +229,7 @@ index 35f2ddf..3cff9dd 100644
  #include <DRAMSys/simulation/DRAMSysRecordable.h>
 diff --git a/src/simulator/simulator/dramsys_conv.h b/src/simulator/simulator/dramsys_conv.h
 new file mode 100644
-index 0000000..7068569
+index 0000000..925b420
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_conv.h
 @@ -0,0 +1,376 @@
@@ -596,7 +596,7 @@ index 0000000..7068569
 +
 +
 +    SC_CTOR(dramsys_conv):
-+    max_pending_req(1),
++    max_pending_req(2),
 +    inflight_read_cnt(0),
 +    memoryManager(true),
 +    iSocket("socket"),

--- a/dramsys_lib/dramsys_lib_patch
+++ b/dramsys_lib/dramsys_lib_patch
@@ -229,10 +229,10 @@ index 35f2ddf..3cff9dd 100644
  #include <DRAMSys/simulation/DRAMSysRecordable.h>
 diff --git a/src/simulator/simulator/dramsys_conv.h b/src/simulator/simulator/dramsys_conv.h
 new file mode 100644
-index 0000000..a9ab650
+index 0000000..7068569
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_conv.h
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,376 @@
 +#pragma once
 +
 +#include "simulator/MemoryManager.h"
@@ -283,7 +283,7 @@ index 0000000..a9ab650
 +    std::list<req_t>                                  read_req_list;
 +    std::list<std::pair<req_t, std::queue<uint8_t>>>  out_order_rsp_list;
 +    std::list<req_t>                                  write_req_list;
-+    std::queue<uint8_t>                               read_rsp_queue;
++    std::deque<uint8_t>                               read_rsp_queue;
 +    std::queue<int>                                   write_rsp_queue;
 +    int                                               max_pending_req;
 +    int                                               inflight_read_cnt;
@@ -418,7 +418,7 @@ index 0000000..a9ab650
 +                {
 +                    uint8_t byte;
 +                    byte = oo_queue.front();
-+                    read_rsp_queue.push(byte);
++                    read_rsp_queue.push_back(byte);
 +                    oo_queue.pop();
 +                }
 +                read_req_list.erase(req_it);
@@ -529,6 +529,11 @@ index 0000000..a9ab650
 +        return write_rsp_queue.size();
 +    }
 +
++    int dram_inflight_req()
++    {
++        return all_req_list.size();
++    }
++
 +    int dram_get_write_rsp()
 +    {
 +        write_rsp_queue.pop();
@@ -542,7 +547,7 @@ index 0000000..a9ab650
 +            if (read_rsp_queue.size())
 +            {
 +                buf[i] = read_rsp_queue.front();
-+                read_rsp_queue.pop();
++                read_rsp_queue.pop_front();
 +            } else {
 +                buf[i] = 0;
 +            }
@@ -555,7 +560,19 @@ index 0000000..a9ab650
 +        if (read_rsp_queue.size())
 +        {
 +            byte = read_rsp_queue.front();
-+            read_rsp_queue.pop();
++            read_rsp_queue.pop_front();
++        } else {
++            byte = 0;
++        }
++        return byte;
++    }
++
++    uint8_t dram_peek_read_rsp_byte(uint32_t index)
++    {
++        uint8_t byte;
++        if (read_rsp_queue.size() > index)
++        {
++            byte = read_rsp_queue.at(index);
 +        } else {
 +            byte = 0;
 +        }
@@ -594,10 +611,10 @@ index 0000000..a9ab650
 +};
 diff --git a/src/simulator/simulator/dramsys_lib.cpp b/src/simulator/simulator/dramsys_lib.cpp
 new file mode 100644
-index 0000000..e23fca7
+index 0000000..6810a40
 --- /dev/null
 +++ b/src/simulator/simulator/dramsys_lib.cpp
-@@ -0,0 +1,294 @@
+@@ -0,0 +1,302 @@
 +#include "Simulator.h"
 +
 +#include <DRAMSys/config/DRAMSysConfiguration.h>
@@ -710,6 +727,10 @@ index 0000000..e23fca7
 +    return list_of_conv[dram_id]->dram_has_write_rsp();
 +}
 +
++extern "C" int dram_inflight_req(int dram_id) {
++    return list_of_conv[dram_id]->dram_inflight_req();
++}
++
 +extern "C" int dram_get_write_rsp(int dram_id) {
 +    return list_of_conv[dram_id]->dram_get_write_rsp();
 +}
@@ -764,6 +785,10 @@ index 0000000..e23fca7
 +    byte_int = (int)byte;
 +    // std::cout << "dram_get_read_rsp_byte: " << byte_int << std::endl;
 +    return byte_int;
++}
++
++extern "C" int dram_peek_read_rsp_byte(int dram_id, int idx) {
++    return (int)list_of_conv[dram_id]->dram_peek_read_rsp_byte(idx);
 +}
 +
 +extern "C" void run_ns(int ns) {

--- a/src/axi_dram_sim.sv
+++ b/src/axi_dram_sim.sv
@@ -1,4 +1,4 @@
-// Copyright 2023 ETH Zurich and 
+// Copyright 2023 ETH Zurich and
 // University of Bologna
 
 // Solderpad Hardware License
@@ -23,9 +23,9 @@ module axi_dram_sim #(
     //DRAM Base Addr
     parameter longint unsigned BASE         = 64'h80000000,
     //DRAM type
-    parameter              DRAMType         = "DDR4",   
-    parameter              CustomerDRAM     = "none",   
-    // AXI interface 
+    parameter              DRAMType         = "DDR4",
+    parameter              CustomerDRAM     = "none",
+    // AXI interface
     parameter type         axi_req_t        = logic,
     parameter type         axi_resp_t       = logic,
     parameter type         axi_ar_t         = logic,
@@ -42,7 +42,7 @@ module axi_dram_sim #(
     input   axi_req_t                       axi_req_i,
     output  axi_resp_t                      axi_resp_o
  );
- 
+
     //define port to DRAM
     localparam int unsigned DramAddrWidth   = AxiAddrWidth;
     localparam int unsigned DramDataWidth   = 512;
@@ -219,4 +219,4 @@ module axi_dram_sim #(
 
 
 
-endmodule : axi_dram_sim 
+endmodule : axi_dram_sim

--- a/src/sim_dram.sv
+++ b/src/sim_dram.sv
@@ -21,6 +21,7 @@ import "DPI-C" function void dram_write_strobe(input int dram_id, input int stro
 import "DPI-C" function void dram_send_req(input int dram_id, input longint addr, input longint length , input longint is_write, input longint strob_enable);
 import "DPI-C" function void dram_get_read_rsp(input int dram_id, input longint length, inout byte buffer[]);
 import "DPI-C" function int dram_get_read_rsp_byte(input int dram_id);
+import "DPI-C" function int dram_peek_read_rsp_byte(input int dram_id, input int idx);
 import "DPI-C" function void dram_preload_byte(input int dram_id, input longint dram_addr_ofst, input int byte_int);
 import "DPI-C" function int dram_check_byte(input int dram_id, input longint dram_addr_ofst);
 import "DPI-C" function void dram_load_elf(input string app_path);
@@ -60,19 +61,6 @@ module sim_dram #(
 typedef logic [7:0] my_byte_t;
 
 int dram_id;
-
-int in_flight_read_dram;
-int in_flight_read_this_module;
-
-byte out_buffer[DataWidth/8-1:0];
-
-always_comb begin
-    my_byte_t [DataWidth/8-1:0] tmp;
-    for (int i = 0; i < (DataWidth/8); i++) begin
-        tmp[i] = out_buffer[i];
-    end
-    rdata_o = tmp;
-end
 
 //initialize model (CTRL + DRAM)
 initial begin
@@ -130,84 +118,56 @@ task preload_elf_binary(input string elf_binary );
     dram_load_elf(elf_binary);
 endtask
 
-always_ff @(negedge clk_i or posedge clk_i or negedge rst_ni) begin : proc_dram
+always_ff @(posedge clk_i or negedge rst_ni) begin : proc_dram
     if(~rst_ni) begin
-        in_flight_read_this_module <=0;
-        in_flight_read_dram <= 0;
-        req_ready_o <= 1;
-        rsp_valid_o <= 0;
-        b_valid_o <= 0;
+        req_ready_o <= 1'b0;
+        rsp_valid_o <= 1'b0;
+        b_valid_o <= 1'b0;
+        rdata_o <= '0;
+    end else begin
+        // Default assignments
+        rsp_valid_o <= 1'b0;
+        b_valid_o <= 1'b0;
+        req_ready_o <= 1'b0;
 
-    end else if (clk_i) begin //posedge clk
-
-        if (rsp_valid_o & rsp_ready_i) begin
-            rsp_valid_o <= 0;
-            in_flight_read_this_module = in_flight_read_this_module -1;
-        end
-
-        if (b_valid_o & b_ready_i) begin
-            b_valid_o <= 0;
+        // Request
+        if (req_valid_i & req_ready_o) begin
+            for (int i = 0; i < (DataWidth/8); i++) begin
+                dram_write_buffer(dram_id, wdata_i[8*i +: 8], i);
+                dram_write_strobe(dram_id, wstrb_i[i], i);
+            end
+            dram_send_req(dram_id, longint'(addr_i), (DataWidth/8), longint'(we_i), !(&wstrb_i) && we_i);
         end
 
         if (dram_can_accept_req(dram_id)) begin
-            req_ready_o <= 1;
-        end else begin
-            req_ready_o <= 0;
+            req_ready_o <= 1'b1;
         end
 
-        if (req_valid_i & req_ready_o) begin
-            byte in_buffer[DataWidth/8-1:0];
-            my_byte_t [DataWidth/8-1:0] tmp;
-            automatic int strob_enable = 0;
-            tmp = wdata_i;
+        // Read response
+        if (rsp_valid_o & rsp_ready_i) begin
             for (int i = 0; i < (DataWidth/8); i++) begin
-                automatic int strb_int = wstrb_i[i];
-                if (strb_int == 0) begin
-                    strob_enable = 1;
-                end
-                in_buffer[i] = tmp[i];
-                dram_write_buffer(dram_id, tmp[i], i);
-                dram_write_strobe(dram_id, strb_int, i);
-            end
-            dram_send_req(dram_id, addr_i, DataWidth/8, we_i, strob_enable & we_i);
-            if (~we_i) begin
-                in_flight_read_this_module = in_flight_read_this_module + 1;
-            end
-        end
-        //update inflight read
-        in_flight_read_dram = dram_get_inflight_read(dram_id);
-
-    end else begin//negedge clk
-
-        //response
-        if (~rsp_valid_o) begin
-            if (dram_has_read_rsp(dram_id)) begin
-                int get_byte_int;
-                byte bt;
-                // dram_get_read_rsp(dram_id, DataWidth/8, out_buffer);
-                for (int i = 0; i < (DataWidth/8); i++) begin
-                    get_byte_int = dram_get_read_rsp_byte(dram_id);
-                    bt = get_byte_int;
-                    out_buffer[i] = bt;
-                end
-                rsp_valid_o <= 1;
+                void'(dram_get_read_rsp_byte(dram_id));
             end
         end
 
-        //write rsp
-        if (~b_valid_o) begin
-            if (dram_has_write_rsp(dram_id)) begin
-                int get_write_int;
-                get_write_int = dram_get_write_rsp(dram_id);
-                b_valid_o <= 1;
+        if (dram_has_read_rsp(dram_id)) begin
+            rsp_valid_o <= 1'b1;
+            for (int i = 0; i < (DataWidth/8); i++) begin
+                rdata_o[8*i +: 8] <= dram_peek_read_rsp_byte(dram_id, i);
             end
         end
 
+
+        // Write response
+        if (b_valid_o & b_ready_i) begin
+            void'(dram_get_write_rsp(dram_id));
+        end
+
+        if (dram_has_write_rsp(dram_id)) begin
+            b_valid_o <= 1;
+        end
     end
-
 end
-
-
 
 final begin
     close_dram(dram_id);

--- a/test/axi_to_dram_tb.sv
+++ b/test/axi_to_dram_tb.sv
@@ -1,4 +1,4 @@
-// Copyright 2023 ETH Zurich and 
+// Copyright 2023 ETH Zurich and
 // University of Bologna
 
 // Solderpad Hardware License
@@ -12,7 +12,7 @@
 // Testbench for dram rtl simulator
 `timescale 1ns/1ps
 
-module axi_to_dram_tb; 
+module axi_to_dram_tb;
 
     `include "axi/assign.svh"
     `include "axi/typedef.svh"
@@ -84,7 +84,7 @@ module axi_to_dram_tb;
     //        DUT       //
     //////////////////////
 
-    dram_sim_engine #(.ClkPeriodNs(4)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
+    dram_sim_engine #(.ClkPeriod(ClkPeriod)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
 
     axi_dram_sim #(
         .AxiAddrWidth(AXI_ADDR_WIDTH),

--- a/test/axi_to_multi_dram_tb.sv
+++ b/test/axi_to_multi_dram_tb.sv
@@ -1,4 +1,4 @@
-// Copyright 2023 ETH Zurich and 
+// Copyright 2023 ETH Zurich and
 // University of Bologna
 
 // Solderpad Hardware License
@@ -91,7 +91,7 @@ module axi_to_multi_dram_tb;
     //        DUT       //
     //////////////////////
 
-    dram_sim_engine #(.ClkPeriodNs(4)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
+    dram_sim_engine #(.ClkPeriod(ClkPeriod)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
 
     axi_dram_sim #(
         .AxiAddrWidth(AXI_ADDR_WIDTH),


### PR DESCRIPTION
### Changed
* The handshake signals are now compliant with the AXI standard i.e. `valid` does not depend on `ready` anymore.
* Valid/Ready signals are only toggled at the positive clock edge, which improves wave debugging and BW _guesstimation_.

### Fixed
* Engines in testbenches used the old `ClkPeriodNs` parameters

### Added
* Basic Github CI to fetch and compile DRAMSys