### PR TITLE
test: Fix dram_sim_engine clock period param

### DIFF
--- a/test/axi_to_dram_tb.sv
+++ b/test/axi_to_dram_tb.sv
@@ -84,7 +84,7 @@ module axi_to_dram_tb;
     //        DUT       //
     //////////////////////
 
-    dram_sim_engine #(.ClkPeriodNs(4)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
+    dram_sim_engine #(.ClkPeriod(ClkPeriod)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
 
     axi_dram_sim #(
         .AxiAddrWidth(AXI_ADDR_WIDTH),

--- a/test/axi_to_multi_dram_tb.sv
+++ b/test/axi_to_multi_dram_tb.sv
@@ -91,7 +91,7 @@ module axi_to_multi_dram_tb;
     //        DUT       //
     //////////////////////
 
-    dram_sim_engine #(.ClkPeriodNs(4)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
+    dram_sim_engine #(.ClkPeriod(ClkPeriod)) i_dram_sim_engine (.clk_i(clk), .rst_ni(rst_n));
 
     axi_dram_sim #(
         .AxiAddrWidth(AXI_ADDR_WIDTH),


### PR DESCRIPTION
Commit ccb54d1 changed the clock period parameter name and type in `dram_sim_engine`. Adjust the testbenches accordingly.