### PR TITLE
Add make recipes to build DRAMSys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ VLOG_ARGS = -svinputport=compat -override_timescale 1ns/1ps -suppress 2583 -supp
 library ?= work
 top_level ?= axi_to_dram_tb
 
+DRAM_RTL_SIM_ROOT = $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# Recipes to build DRAMSys
+include dram_rtl_sim.mk
 
 # Path to DRAMsyslib
 dramsys_resouces_path ?= ../dramsys_lib/DRAMSys/configs

--- a/README.md
+++ b/README.md
@@ -12,27 +12,14 @@ This tool aids in system-level hardware simulations, particularly for large chip
 
 ### 🔨 Build DRAMSys Dynamic Linkable Library
 
-Follow the steps below to build the DRAMSys dynamic linkable libraries:
+To download, patch, and build the DRAMSys dynamic linkable libraries, run
+```shell
+make -j dramsys
+```
 
-1. Clone the DRAMSys5.0 repository and apply the necessary patches:
-    ```shell
-    cd dramsys_lib
-    git clone https://github.com/tukl-msd/DRAMSys.git
-    cd DRAMSys
-    git reset --hard 8e021ea
-    git apply ../dramsys_lib_patch
-    ```
-
-2. Build the DRAMSys dynamic linkable library within the `dramsys_lib/DRAMSys` directory:
-    ```shell
-    mkdir build
-    cd build
-    cmake -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC -D DRAMSYS_WITH_DRAMPOWER=ON ..
-    make -j
-    ```
-    After building, two key libraries will be available in `dramsys_lib/DRAMSys/build/lib`:
-    - `libsystemc.so`
-    - `libDRAMSys_Simulator.so`
+After building, two key libraries will be available in `dramsys_lib/DRAMSys/build/lib`:
+- `libsystemc.so`
+- `libDRAMSys_Simulator.so`
 
 ### 🧪 (Optional) Test RTL-DRAMSys Co-simulation
 

--- a/dram_rtl_sim.mk
+++ b/dram_rtl_sim.mk
@@ -1,0 +1,27 @@
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+BENDER ?= bender
+CMAKE ?= cmake
+DRAM_RTL_SIM_ROOT ?= $(shell $(BENDER) path axi_dram_sim)
+DRAMSYS_ROOT ?= $(DRAM_RTL_SIM_ROOT)/dramsys_lib/DRAMSys
+DRAMSYS_BUILD_DIR ?= $(DRAMSYS_ROOT)/build
+
+dramsys: $(DRAMSYS_BUILD_DIR)/lib/libsystemc.so
+
+$(DRAMSYS_BUILD_DIR):
+	mkdir -p $@
+
+# Clone and patch DRAMSys
+$(DRAMSYS_ROOT)/.patched:
+	git clone https://github.com/tukl-msd/DRAMSys.git $(DRAMSYS_ROOT)
+	cd $(DRAMSYS_ROOT) && git reset --hard 8e021ea && git apply $(DRAM_RTL_SIM_ROOT)/dramsys_lib/dramsys_lib_patch
+	@touch $@
+
+# Build DRAMSys
+$(DRAMSYS_BUILD_DIR)/lib/libsystemc.so: $(DRAMSYS_ROOT)/.patched $(DRAMSYS_BUILD_DIR)
+	cd $(DRAMSYS_BUILD_DIR) && $(CMAKE) -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC -D DRAMSYS_WITH_DRAMPOWER=ON $(DRAMSYS_ROOT)
+	$(MAKE) -C $(DRAMSYS_BUILD_DIR)


### PR DESCRIPTION
Add `make` recipes to download, patch, and build DRAMSys. Recipes are located in a standalone Makefragment to make them reusable. Furthermore, update `README.md` to use these make flows.