### PR TITLE
Remove DRAMSYS_ROOT before cloning, guard bender targets

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -13,9 +13,11 @@ dependencies:
 
 sources:
   #level 1 
-  - src/sim_dram.sv
-  - src/axi_dram_sim.sv
-  - src/dram_sim_engine.sv
+  - target: any(simulation, verilator)
+    files:
+      - src/sim_dram.sv
+      - src/axi_dram_sim.sv
+      - src/dram_sim_engine.sv
 
   - target: test
     files:

--- a/dram_rtl_sim.mk
+++ b/dram_rtl_sim.mk
@@ -17,6 +17,7 @@ $(DRAMSYS_BUILD_DIR):
 
 # Clone and patch DRAMSys
 $(DRAMSYS_ROOT)/.patched:
+	rm -rf $(DRAMSYS_ROOT)
 	git clone https://github.com/tukl-msd/DRAMSys.git $(DRAMSYS_ROOT)
 	cd $(DRAMSYS_ROOT) && git reset --hard 8e021ea && git apply $(DRAM_RTL_SIM_ROOT)/dramsys_lib/dramsys_lib_patch
 	@touch $@


### PR DESCRIPTION
Hi @husterZC, sorry for opening another PR. I had a chat with @paulsc96 and the following modifications would be appreciated for the DRAMSys integration into Cheshire:
- `dram_rtl_sim.mk`: Remove `DRAMSYS_ROOT` before cloning it. This prevents errors when building this target multiple times.
- `Bender.yml`: Guard the source files to only include them when targeting simulation to prevent issues with synthesis tools.

Once this is merged, could you also create a release tag? e.g. `v0.1.0` or `v1.0.0`.

Thanks a lot!