### PR TITLE
Makefrag: Remove directory target breaking parallel build

### DIFF
--- a/dram_rtl_sim.mk
+++ b/dram_rtl_sim.mk
@@ -12,9 +12,6 @@ DRAMSYS_BUILD_DIR ?= $(DRAMSYS_ROOT)/build
 
 dramsys: $(DRAMSYS_BUILD_DIR)/lib/libsystemc.so
 
-$(DRAMSYS_BUILD_DIR):
-	mkdir -p $@
-
 # Clone and patch DRAMSys
 $(DRAMSYS_ROOT)/.patched:
 	rm -rf $(DRAMSYS_ROOT)
@@ -23,6 +20,7 @@ $(DRAMSYS_ROOT)/.patched:
 	@touch $@
 
 # Build DRAMSys
-$(DRAMSYS_BUILD_DIR)/lib/libsystemc.so: $(DRAMSYS_ROOT)/.patched $(DRAMSYS_BUILD_DIR)
+$(DRAMSYS_BUILD_DIR)/lib/libsystemc.so: $(DRAMSYS_ROOT)/.patched
+	mkdir -p $(DRAMSYS_BUILD_DIR)
 	cd $(DRAMSYS_BUILD_DIR) && $(CMAKE) -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC -D DRAMSYS_WITH_DRAMPOWER=ON $(DRAMSYS_ROOT)
 	$(MAKE) -C $(DRAMSYS_BUILD_DIR)


### PR DESCRIPTION
By creating the build directory `DRAMSYS_BUILD_DIR` through its own target, a parallel invocation of make (i.e. with the `-j` flag) will create it *before* building `$(DRAMSYS_ROOT)/.patched`, which clones DRAMSys.

As the now existing `DRAMSYS_BUILD_DIR` is within `DRAMSYS_ROOT`, Git will refuse to clone into`DRAMSYS_ROOT`  as the target directory is not empty, failing the build of `$(DRAMSYS_ROOT)/.patched` and any dependents.

We solve this by directly creating the `DRAMSYS_BUILD_DIR` directory inside the build step for `$(DRAMSYS_BUILD_DIR)/lib/libsystemc.so`.