### PR TITLE
Add working baseline environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@
 # Chi Zhang <chizhang@iis.ee.ethz.ch>
 
 BENDER ?= bender
+QUESTA ?= questa
+CMAKE ?= cmake
+
+
+
 VLOG_ARGS = -svinputport=compat -override_timescale 1ns/1ps -suppress 2583 -suppress 13314
 library ?= work
 top_level ?= axi_to_dram_tb
@@ -24,17 +29,17 @@ questa_args += -sv_lib $(dramsys_lib_path)/libsystemc
 questa_args += -sv_lib $(dramsys_lib_path)/libDRAMSys_Simulator
 
 all: compile
-	cd vsim && questa vsim -c $(library).$(top_level) -t 1ps -voptargs=+acc $(questa_args) -do start.tcl
+	cd vsim && $(QUESTA) vsim -c $(library).$(top_level) -t 1ps -voptargs=+acc $(questa_args) -do start.tcl
 
 gui: compile
-	cd vsim && questa vsim $(library).$(top_level) -t 1ps -voptargs=+acc $(questa_args) -do start.tcl
+	cd vsim && $(QUESTA) vsim $(library).$(top_level) -t 1ps -voptargs=+acc $(questa_args) -do start.tcl
 
-compile: vsim/compile.tcl
+compile: vsim/compile.tcl dramsys
 	echo "exit" >> vsim/compile.tcl
-	cd vsim && questa vsim -c -do compile.tcl
+	cd vsim && $(QUESTA) vsim -c -do compile.tcl
 
 vsim/compile.tcl: Bender.yml Makefile $(shell find src -type f) $(shell find test -type f) 
 	$(BENDER) script vsim -t test -t rtl --vlog-arg="$(VLOG_ARGS)" > $@
 
-clean:
+clean: dramsys-clean
 	cd vsim && rm -rf work/ vsim*  transcript  modelsim.ini compile.tcl .nfs* DRAM*

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool aids in system-level hardware simulations, particularly for large chip
 
 - This tool leverages [`bender`](https://github.com/pulp-platform/bender) for dependency management and automatic generation of compilation scripts.
 - Note: We currently do not offer an open-source simulation setup. Instead, we have utilized `Questasim` for simulation.
-- For building DRAMSys, cmake version >= 3.28.1 is required.
+- For building DRAMSys, cmake version >= 3.28.1 and GCC version >= 11.2.0 is required.
 
 ### 🔨 Build DRAMSys Dynamic Linkable Library
 

--- a/dram_rtl_sim.mk
+++ b/dram_rtl_sim.mk
@@ -10,6 +10,9 @@ DRAM_RTL_SIM_ROOT ?= $(shell $(BENDER) path axi_dram_sim)
 DRAMSYS_ROOT ?= $(DRAM_RTL_SIM_ROOT)/dramsys_lib/DRAMSys
 DRAMSYS_BUILD_DIR ?= $(DRAMSYS_ROOT)/build
 
+CC ?= gcc
+CXX ?= g++
+
 dramsys: $(DRAMSYS_BUILD_DIR)/lib/libsystemc.so
 
 # Clone and patch DRAMSys
@@ -24,3 +27,8 @@ $(DRAMSYS_BUILD_DIR)/lib/libsystemc.so: $(DRAMSYS_ROOT)/.patched
 	mkdir -p $(DRAMSYS_BUILD_DIR)
 	cd $(DRAMSYS_BUILD_DIR) && $(CMAKE) -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC -D DRAMSYS_WITH_DRAMPOWER=ON $(DRAMSYS_ROOT)
 	$(MAKE) -C $(DRAMSYS_BUILD_DIR)
+
+.PHONY: dramsys-clean
+
+dramsys-clean:
+	rm -rf $(DRAMSYS_BUILD_DIR)/

--- a/iis-env.sh
+++ b/iis-env.sh
@@ -1,0 +1,5 @@
+export CC=gcc-11.2.0
+export CXX=g++-11.2.0
+export CMAKE=cmake-3.28.3
+export QUESTA=questa-2022.3
+export BENDER=bender


### PR DESCRIPTION
This PR replaces the hardcoded reference to the questa binary with an environment variable.
It also adds the `iis-env.sh` script to establish a working baseline environment with the correct Questa, make, and GCC versions.
